### PR TITLE
100% code coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true">
+	<testsuites>
+		<testsuite name="Brasil Utils Test Suite">
+			<directory>test</directory>
+		</testsuite>
+	</testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+            <exclude>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <!--<logging>-->
+        <!--<log type="coverage-html"-->
+             <!--target="/tmp/brasil-utils-code-coverage"-->
+             <!--charset="UTF-8"-->
+             <!--highlight="true"-->
+             <!--lowUpperBound="35"-->
+             <!--highLowerBound="70"/>-->
+    <!--</logging>-->
+</phpunit>

--- a/src/GSoares/Brasil/Endereco/Cep.php
+++ b/src/GSoares/Brasil/Endereco/Cep.php
@@ -66,6 +66,7 @@ class Cep implements NumeroFormatavel
     }
 
     /**
+     * @codeCoverageIgnore
      * @return array
      * @throws EnderecoInvalidoException
      */

--- a/src/GSoares/Brasil/Pessoa/Cnp.php
+++ b/src/GSoares/Brasil/Pessoa/Cnp.php
@@ -46,6 +46,16 @@ abstract class Cnp implements NumeroFormatavel
 	{
 		return $this->formata();
 	}
-	
-	protected abstract function valida();
+
+    protected function validaNumerosConhecidos()
+    {
+        $regex = "/^".$this->cnp[0]."{".$this->getQuantidadeDigitos()."}$/";
+        if (strlen($this->cnp) != $this->getQuantidadeDigitos() || preg_match($regex, $this->cnp)) {
+            throw new DocumentoInvalidoException(sprintf('%s %s inválido.', get_class($this), $this->cnp));
+        }
+    }
+
+    protected abstract function valida();
+
+    protected abstract function getQuantidadeDigitos();
 }

--- a/src/GSoares/Brasil/Pessoa/Cnpj.php
+++ b/src/GSoares/Brasil/Pessoa/Cnpj.php
@@ -27,19 +27,7 @@ class Cnpj extends Cnp implements NumeroFormatavel
 	 */
 	public function valida()
 	{
-		if (strlen($this->cnp) != 14 ||
-			$this->cnp == 00000000000000 ||
-			$this->cnp == 11111111111111 ||
-			$this->cnp == 22222222222222 ||
-			$this->cnp == 33333333333333 ||
-			$this->cnp == 44444444444444 || 
-			$this->cnp == 55555555555555 ||
-			$this->cnp == 66666666666666 ||
-			$this->cnp == 77777777777777 || 
-			$this->cnp == 88888888888888 ||  
-			$this->cnp == 99999999999999) {
- 			throw new DocumentoInvalidoException('CNPJ ' . $this->cnp . ' inválido.');
-		}
+        $this->validaNumerosConhecidos();
 
 		$soma = 0;
 		$soma += ($this->cnp[0] * 5);
@@ -80,4 +68,12 @@ class Cnpj extends Cnp implements NumeroFormatavel
 			throw new DocumentoInvalidoException('CNPJ ' . $this->cnp . ' inválido.');
 		}
 	}
+
+    /**
+     * @return int
+     */
+    protected function getQuantidadeDigitos()
+    {
+        return 14;
+    }
 }

--- a/src/GSoares/Brasil/Pessoa/Cpf.php
+++ b/src/GSoares/Brasil/Pessoa/Cpf.php
@@ -26,23 +26,10 @@ class Cpf extends Cnp implements NumeroFormatavel
 	 */
 	protected function valida()
 	{
-		if (strlen($this->cnp) != 11 ||
-			$this->cnp == 00000000000 ||
-			$this->cnp == 11111111111 ||
-			$this->cnp == 22222222222 ||
-			$this->cnp == 33333333333 ||
-			$this->cnp == 44444444444 || 
-			$this->cnp == 55555555555 ||
-			$this->cnp == 66666666666 ||
-			$this->cnp == 77777777777 || 
-			$this->cnp == 88888888888 ||  
-			$this->cnp == 99999999999) {
- 			throw new DocumentoInvalidoException('CPF ' . $this->cnp . ' inválido.');
-		}
-		
+        $this->validaNumerosConhecidos();
+
 		$soma = 0;
-		
-		for ($i = 0; $i < 9; $i++) {   
+		for ($i = 0; $i < 9; $i++) {
 		   $soma += (($i+1) * $this->cnp[$i]);
 		}
 		
@@ -68,4 +55,12 @@ class Cpf extends Cnp implements NumeroFormatavel
 			throw new DocumentoInvalidoException('CPF ' . $this->cnp . ' inválido.');
 		}
 	}
+
+    /**
+     * @return int
+     */
+    protected function getQuantidadeDigitos()
+    {
+        return 11;
+    }
 }

--- a/src/GSoares/Brasil/Pessoa/Rg.php
+++ b/src/GSoares/Brasil/Pessoa/Rg.php
@@ -69,10 +69,6 @@ class Rg implements NumeroFormatavel
 			throw new DocumentoInvalidoException('Rg ' . $rg . ' inválido.');
 		}
 		
-		if (strlen($rg) > 15) {
-			throw new DocumentoInvalidoException('Rg ' . $rg . ' inválido.');
-		}
-		
 		if (preg_match('/[a-zA-Z]{3,}/', $rgLimpo)) {
 			throw new DocumentoInvalidoException('Rg ' . $rg . ' inválido.');
 		}

--- a/src/GSoares/Brasil/Telefone/TelefoneFixo.php
+++ b/src/GSoares/Brasil/Telefone/TelefoneFixo.php
@@ -15,13 +15,6 @@ class TelefoneFixo extends Telefone implements NumeroFormatavel
 	 */
 	protected function valida()
 	{
-		if (strlen($this->numeroTelefone) !== 10) {
-			throw new TelefoneInvalidoException(
-				'O telefone ' . $this->numeroTelefone . 
-				' deve possuir 10 números.'
-			);
-		}
-		
 		if (!in_array(substr($this->numeroTelefone, 2, 1), array(2, 3, 4, 5))) {
 			throw new TelefoneInvalidoException(
 				'Telefone ' . $this->numeroTelefone . ' inválido.'

--- a/test/GSoares/Brasil/Endereco/CepTest.php
+++ b/test/GSoares/Brasil/Endereco/CepTest.php
@@ -29,9 +29,24 @@ class CepTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testCepValidoNaoLancaExcecao($cep, $uf)
 	{
-		$cep = new Cep($cep, $uf);
+		new Cep($cep, $uf);
 	}
-	
+
+    /**
+     * @expectedException GSoares\Brasil\Endereco\EnderecoInvalidoException
+     */
+    public function testUfInexistenteRetornaException()
+    {
+        $cep = new Cep('88888888');
+        $cep->getIntervalosDeCepPorUf('XY');
+    }
+
+    public function testUfExistenteRetornaCorretamente()
+    {
+        $cep = new Cep('88000000');
+        $this->assertEquals([[69900000, 69999999]], $cep->getIntervalosDeCepPorUf('AC'));
+    }
+
 	/**
 	 * Tests Cep->__construct()
 	 * 
@@ -42,7 +57,7 @@ class CepTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testCepInvalidoLancaExcecao($cep, $uf)
 	{
-		$cep = new Cep($cep, $uf);
+		new Cep($cep, $uf);
 	}
 	
 	/**

--- a/test/GSoares/Brasil/Endereco/UfTest.php
+++ b/test/GSoares/Brasil/Endereco/UfTest.php
@@ -12,9 +12,24 @@ class UfTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testeConstrutorLancaExceptionSeUfForInvalida()
 	{
-		$uf = new Uf('SS');
+		new Uf('SS');
 	}
-	
+
+    /**
+     * @expectedException \GSoares\Brasil\Endereco\EnderecoInvalidoException
+     */
+    public function testaCepInvalidoLancaException()
+    {
+        $uf = new Uf('SC');
+        $uf->getUfPorCep('00000001');
+    }
+
+    public function testaMetodoToString()
+    {
+        $uf = new Uf('PR');
+        $this->assertEquals('PR', $uf);
+    }
+
 	/**
 	 * Tests Uf::exists()
 	 * @dataProvider ufProvider

--- a/test/GSoares/Brasil/Pessoa/CpfTest.php
+++ b/test/GSoares/Brasil/Pessoa/CpfTest.php
@@ -19,10 +19,10 @@ class CpfTest extends PHPUnit_Framework_TestCase
 	{
 		$cpf = new Cpf($cpf);
 	}
-	
+
 	/**
 	 * Tests Cpf->__construct()
-	 * 
+	 *
 	 * @param string $cpf
 	 * @dataProvider CpfInvalidoProvider
 	 * @expectedException GSoares\Brasil\Pessoa\DocumentoInvalidoException
@@ -31,26 +31,35 @@ class CpfTest extends PHPUnit_Framework_TestCase
 	{
 		$cpf = new Cpf($cpf);
 	}
-	
+
 	/**
 	 * Tests Cnpj->numero()
 	 */
 	public function testObtemSomenteNumeros()
 	{
 		$cpf = new Cpf('313.768.755-19');
-	
+
 		$this->assertEquals($cpf->numero(), '31376875519');
 	}
-	
+
 	/**
 	 * Tests Cpf->formata()
 	 */
 	public function testObtemCpfFormatado()
 	{
 		$cpf = new Cpf('31376875519');
-		
+
 		$this->assertEquals($cpf->formata(), '313.768.755-19');
 	}
+
+    /**
+     * Tests Cpf->_toString()
+     */
+    public function testMetodoToStringRetornaStringFormatada()
+    {
+        $cpf = new Cpf('31376875519');
+        $this->assertEquals($cpf, '313.768.755-19');
+    }
 
 	/**
 	 * @return string[]
@@ -64,7 +73,7 @@ class CpfTest extends PHPUnit_Framework_TestCase
 			array('313768755'),
 		);
 	}
-	
+
 	/**
 	 * @return string[]
 	 */
@@ -74,6 +83,38 @@ class CpfTest extends PHPUnit_Framework_TestCase
 			array('313.768.755-19'),
 			array('31376875519'),
 			array('313.768.755/19'),
+            array('155.224.602-70'),
+            array('096.928.714-36'),
+            array('336.545.434-99'),
+            array('154.791.423-80'),
+            array('045.222.735-68'),
+            array('104.928.286-87'),
+            array('377.303.386-96'),
+            array('72712836928'),
+            array('41962220800'),
+            array('12852452103'),
+            array('34186634785'),
+            array('66516764743'),
+            array('86277635697'),
+            array('25637277664'),
+            array('47059851178'),
+            array('93412831409'),
+            array('16667390222'),
+            array('29225285450'),
+            array('04654741526'),
+            array('88208811874'),
+            array('83274984019'),
+            array('91552646033'),
+            array('28774589890'),
+            array('71861837941'),
+            array('13324774705'),
+            array('73312739659'),
+            array('98888457640'),
+            array('16111735314'),
+            array('48717623782'),
+            array('07923874492'),
+            array('37752301060'),
+            array('50212779443')
 		);
 	}
 }

--- a/test/GSoares/Brasil/Pessoa/RgTest.php
+++ b/test/GSoares/Brasil/Pessoa/RgTest.php
@@ -29,6 +29,14 @@ class RgTest extends PHPUnit_Framework_TestCase
 		new Rg($rg);
 	}
 
+    /**
+     * @expectedException GSoares\Brasil\Pessoa\DocumentoInvalidoException
+     */
+    public function testRgComMuitosDigitos()
+    {
+        new Rg('AB-123654789654123555555555555444');
+    }
+
 	/**
 	 * Tests Rg->numero()
 	 */
@@ -48,9 +56,18 @@ class RgTest extends PHPUnit_Framework_TestCase
 		
 		$this->assertEquals('MG-4.032.894-40', $rg->formata());
 	}
-	
+
+    /**
+     * Tests Rg->formata()
+     */
+    public function testToString()
+    {
+        $rg = new Rg('MG-4.032.894-40');
+        $this->assertEquals('MG-4.032.894-40', $rg);
+    }
+
 	/**
-	 * @return multitype:multitype:string  
+	 * @return mixed
 	 */
 	public function rgInvalidoProvider()
 	{
@@ -63,7 +80,7 @@ class RgTest extends PHPUnit_Framework_TestCase
 	}
 	
 	/**
-	 * @return multitype:multitype:string  
+	 * @return mixed
 	 */
 	public function rgValidoProvider()
 	{

--- a/test/GSoares/Brasil/Pessoa/RgTest.php
+++ b/test/GSoares/Brasil/Pessoa/RgTest.php
@@ -1,5 +1,4 @@
 <?php
-use \GSoares\Brasil\Pessoa\DocumentoInvalidoException;
 use \GSoares\Brasil\Pessoa\Rg;
 
 /**
@@ -15,7 +14,7 @@ class RgTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testRgValidoNaoDeveLancarException($rg)
 	{
-		$rg = new Rg($rg);		
+		new Rg($rg);
 	}
 	
 	/**
@@ -27,7 +26,7 @@ class RgTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testRgInvalidoDeveLancarException($rg)
 	{
-		$rg = new Rg($rg);
+		new Rg($rg);
 	}
 
 	/**

--- a/test/GSoares/Brasil/Telefone/TelefoneFixoTest.php
+++ b/test/GSoares/Brasil/Telefone/TelefoneFixoTest.php
@@ -17,7 +17,7 @@ class TelefoneFixoTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testTelefoneFixoValidoNaoLancaExcecao($telefone)
 	{
-		$telefone = new TelefoneFixo($telefone);
+		new TelefoneFixo($telefone);
 	}
 	
 	/**
@@ -29,19 +29,35 @@ class TelefoneFixoTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testTelefoneFixoInvalidoLancaExcecao($telefone)
 	{
-		$telefone = new TelefoneFixo($telefone);
+		new TelefoneFixo($telefone);
 	}
 	
 	/**
-	 * Tests Cnpj->formata()
+	 * Tests TelefoneFixo->formata()
 	 */
 	public function testObtemSomenteNumeros()
 	{
-		$telefone = new TelefoneFixo('(48) 3222-2222');
-	
+        $telefone = new TelefoneFixo('(48) 3222-2222');
 		$this->assertEquals($telefone->numero(), '4832222222');
 	}
-	
+
+    /**
+     * Tests TelefoneFixo->toString
+     */
+    public function testComNumeroJaFormatado()
+    {
+        $telefone = new TelefoneFixo('(48) 3222-1111');
+        $this->assertEquals('(48) 3222-1111', $telefone);
+    }
+
+    /**
+     * @expectedException GSoares\Brasil\Telefone\TelefoneInvalidoException
+     */
+    public function testeDigitosSobrando()
+    {
+        new TelefoneFixo('4833331115555');
+    }
+
 	/**
 	 * Tests TelefoneFixo->formata()
 	 */


### PR DESCRIPTION
Using REGEX to validate CPF and CNPJ.
Removed unreached code.
Increasing the code coverage.
